### PR TITLE
Feature/check flow on depth zero only

### DIFF
--- a/ptoxyspherex.sol
+++ b/ptoxyspherex.sol
@@ -1,0 +1,25 @@
+Compiling 13 files with 0.8.23
+Solc 0.8.23 finished in 484.71ms
+Compiler run [33msuccessful with warnings:[0m
+[1;33mWarning (2519)[0m[1;37m: This declaration shadows an existing declaration.[0m
+   [34m-->[0m src/SphereXProtectedBase.sol:213:9:
+[34m    |[0m
+[34m213 |[0m         [33mISphereXEngine sphereXEngine[0m = _sphereXEngine();
+[34m    |[0m         [1;33m^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
+[1;36mNote[0m[1;37m: The shadowed declaration is here:[0m
+   [34m-->[0m src/SphereXProtectedBase.sol:130:5:
+[34m    |[0m
+[34m130 |[0m     [33mfunction sphereXEngine() public view returns (address) {[0m
+[34m    |[0m     [1;33m^ (Relevant source part starts here and spans across multiple lines).[0m
+
+[1;33mWarning (2519)[0m[1;37m: This declaration shadows an existing declaration.[0m
+   [34m-->[0m src/SphereXProtectedBase.sol:237:9:
+[34m    |[0m
+[34m237 |[0m         [33mISphereXEngine sphereXEngine[0m = _sphereXEngine();
+[34m    |[0m         [1;33m^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
+[1;36mNote[0m[1;37m: The shadowed declaration is here:[0m
+   [34m-->[0m src/SphereXProtectedBase.sol:130:5:
+[34m    |[0m
+[34m130 |[0m     [33mfunction sphereXEngine() public view returns (address) {[0m
+[34m    |[0m     [1;33m^ (Relevant source part starts here and spans across multiple lines).[0m
+

--- a/test/SphereXEngine.t.sol
+++ b/test/SphereXEngine.t.sol
@@ -655,6 +655,22 @@ contract SphereXEngineTest is Test, CFUtils {
         sendExternalNumberToEngine(2);
         vm.expectRevert("SphereX error: disallowed tx pattern");
         sendExternalNumberToEngine(-2);
-
+    }
+    function test_check_only_on_depth_zero_2_cf() public activateRule(CF) {
+        spherex_engine.setFlowCheckOnZeroDepth(true);
+        allowed_cf_storage = [int256(1),2,-2, -1];
+        addAllowedPattern();
+        allowed_cf_storage = [int256(3),-3];
+        addAllowedPattern();
+        
+        sendExternalNumberToEngine(1);
+        sendExternalNumberToEngine(2);
+        sendExternalNumberToEngine(-2);
+        sendExternalNumberToEngine(-1);
+        sendExternalNumberToEngine(3);
+        sendExternalNumberToEngine(-3);
+        sendExternalNumberToEngine(4);
+        vm.expectRevert("SphereX error: disallowed tx pattern");
+        sendExternalNumberToEngine(-4);
     }
 }

--- a/test/SphereXEngine.t.sol
+++ b/test/SphereXEngine.t.sol
@@ -638,4 +638,23 @@ contract SphereXEngineTest is Test, CFUtils {
             sendInternalNumberToEngine(not_allowed_cf[i]);
         }
     }
+
+    function test_check_only_on_depth_zero(bytes8 rule) public activateRule(rule) {
+        spherex_engine.setFlowCheckOnZeroDepth(true);
+        allowed_cf_storage = [int256(1),2,-2, -1];
+        addAllowedPattern();
+
+        sendExternalNumberToEngine(1);
+        sendExternalNumberToEngine(2);
+        sendExternalNumberToEngine(-2);
+        sendExternalNumberToEngine(-1);
+        vm.roll(200);
+        spherex_engine.setFlowCheckOnZeroDepth(false);
+
+        sendExternalNumberToEngine(1);
+        sendExternalNumberToEngine(2);
+        vm.expectRevert("SphereX error: disallowed tx pattern");
+        sendExternalNumberToEngine(-2);
+
+    }
 }

--- a/test/SphereXEngineSelectiveTxf.t.sol
+++ b/test/SphereXEngineSelectiveTxf.t.sol
@@ -18,16 +18,6 @@ contract SphereXEngineSelectiveTxfTest is Test, CFUtils {
         spherex_engine.configureRules(bytes8(SELECTIVE_TXF));
     }
 
-    function sendExternalNumberToEngine(int256 num) private {
-        bytes32[] memory emptyArray = new bytes32[](0);
-        bytes memory emptyArray2 = new bytes(0);
-        if (num > 0) {
-            spherex_engine.sphereXValidatePre(num, random_address, emptyArray2);
-        } else {
-            spherex_engine.sphereXValidatePost(num, 0, emptyArray, emptyArray);
-        }
-    }
-
     //  ============ Test for the management functions  ============
 
     function test_SelectiveTxf_not_included_function() public {

--- a/test/Utils/CFUtils.sol
+++ b/test/Utils/CFUtils.sol
@@ -92,4 +92,14 @@ contract CFUtils is Test {
             spherex_engine.sphereXValidateInternalPost(num, 0, emptyArray, emptyArray);
         }
     }
+
+    function sendExternalNumberToEngine(int256 num) internal {
+        if (num > 0) {
+            bytes memory empty;
+            spherex_engine.sphereXValidatePre(num, address(0), empty);
+        } else {
+            bytes32[] memory emptyArray = new bytes32[](0);
+            spherex_engine.sphereXValidatePost(num, 0, emptyArray, emptyArray);
+        }
+    }
 }


### PR DESCRIPTION
this is for dexe, this hopefully will solve their gas issues with approving alot of transactions.
Now. a client can configure if he wishes the pattern to be checked at the end of the call flow or in every external call exit.